### PR TITLE
Map.java: Remove red pin markers from map

### DIFF
--- a/app/src/main/java/com/red/alert/activities/Map.java
+++ b/app/src/main/java/com/red/alert/activities/Map.java
@@ -322,12 +322,6 @@ public class Map extends AppCompatActivity implements OnMapsSdkInitializedCallba
                     tooltip = LocationData.getDistanceFromCity(city, this) + " " + getString(R.string.kilometer);
                 }
 
-                // Add marker to map
-                mMap.addMarker(new MarkerOptions()
-                        .position(location)
-                        .title(localizedName)
-                        .snippet(tooltip));
-
                 // Include location in zoom boundaries
                 builder.include(location);
 


### PR DESCRIPTION
Remove mMap.addMarker() calls to display only polygon overlays for
alert areas, without individual pin markers for each city.

<img width="369" height="703" alt="image" src="https://github.com/user-attachments/assets/56eb1bc5-4b1d-4465-8327-17b278f63ee9" />

<img width="470" height="763" alt="image" src="https://github.com/user-attachments/assets/7bc985e2-bb0a-4201-bea7-bad1e9601206" />