### PR TITLE
Fix settings overlap with system navigation bar in landscape mode

### DIFF
--- a/app/src/main/java/com/red/alert/utils/ui/NavbarUtil.java
+++ b/app/src/main/java/com/red/alert/utils/ui/NavbarUtil.java
@@ -19,18 +19,18 @@ public class NavbarUtil {
         // Set fits system window & background color (so it appears below navbar)
         root.setFitsSystemWindows(true);
 
-        // Fix Android 15 navbar overlay bug
-        if (Build.VERSION.SDK_INT == 35) {
+        // Fix navbar overlay in landscape mode
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             // Wait for insets
             ViewCompat.setOnApplyWindowInsetsListener(root, (v, insets) -> {
                 // Get system bar insets
                 Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
 
-                // Apply top & bottom padding
+                // Apply padding for all sides (handles landscape mode)
                 v.setPadding(
-                        v.getPaddingLeft(),
+                        bars.left,
                         bars.top,
-                        v.getPaddingRight(),
+                        bars.right,
                         bars.bottom
                 );
 


### PR DESCRIPTION
Applied proper padding for all sides (left, right, top, bottom) to handle
system bar insets in landscape orientation. Previously only top and bottom
padding were applied, causing settings content to overlap with the
navigation bar on the right side in landscape mode.

Changed Android version check from Build.VERSION.SDK_INT == 35 to >= LOLLIPOP
to apply the fix on all modern Android versions that support window insets.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
